### PR TITLE
fix: remove private from enabler package.json

### DIFF
--- a/enabler/package.json
+++ b/enabler/package.json
@@ -1,6 +1,5 @@
 {
   "name": "enabler",
-  "private": "true",
   "version": "0.0.1",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Remove `  "private": "true",` from the package.json for allowing connect build