### PR TITLE
[SCC-2899] Gift Card Connector Changes for Error

### DIFF
--- a/enabler/src/components/utils.ts
+++ b/enabler/src/components/utils.ts
@@ -3,6 +3,22 @@ import inputFieldStyles from '../style/inputField.module.scss';
 
 export const getInput = (field: string) => document.querySelector(`#${field}`) as HTMLInputElement;
 
+export const showError = (field: string, textContent: string) => {
+  const input = getInput(field);
+  input.parentElement.classList.add(inputFieldStyles.error);
+  const errorElement = input.parentElement.querySelector(`#${field} + .${inputFieldStyles.errorField}`);
+  errorElement.textContent = textContent;
+  errorElement.classList.remove(inputFieldStyles.hidden);
+};
+
+export const hideError = (field: string) => {
+  const input = getInput(field);
+  input.parentElement.classList.remove(inputFieldStyles.error);
+  const errorElement = input.parentElement.querySelector(`#${field} + .${inputFieldStyles.errorField}`);
+  errorElement.textContent = '';
+  errorElement.classList.add(inputFieldStyles.hidden);
+};
+
 export const fieldIds = {
   code: 'giftcard-code',
 };
@@ -24,4 +40,31 @@ const handleChangeEvent = (field: string, onValueChange?: (hasValue: boolean) =>
 
 export const addFormFieldsEventListeners = (giftcardOptions: GiftCardOptions) => {
   handleChangeEvent(fieldIds.code, giftcardOptions?.onValueChange);
+  handleChangeEvent(fieldIds.code, async () => hideError(fieldIds.code));
+  handleEnter(fieldIds.code, giftcardOptions?.onEnter);
+};
+
+type Res = {
+  status: {
+    state: string;
+    errors?: {
+      code: string;
+      message: string;
+    }[];
+  };
+  amount?: {
+    centAmount: number;
+    currencyCode: string;
+  };
+};
+
+export const getErrorCode = (res: Res): string | null =>
+  res.status.state !== 'Valid' ? res.status.errors?.[0].code || 'GenericError' : null;
+
+export const handleEnter = (field: string, callback: (e: Event) => void) => {
+  getInput(field).addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.keyCode === 13) {
+      callback(e);
+    }
+  });
 };

--- a/enabler/src/i18n/index.ts
+++ b/enabler/src/i18n/index.ts
@@ -16,4 +16,9 @@ export default class I18n {
     }
     return this.translations[normalizedLang]?.[key] || this.translations[defaultLanguage]?.[key] || key;
   }
+
+  keyExists(key: string, lang: string | undefined): boolean {
+    const normalizedLang = normalizeLanguageCode(lang || defaultLanguage);
+    return !!this.translations[normalizedLang]?.[key] || !!this.translations[defaultLanguage]?.[key];
+  }
 }

--- a/enabler/src/i18n/translations.ts
+++ b/enabler/src/i18n/translations.ts
@@ -3,6 +3,11 @@ import { Translations } from './definitions';
 export const translations: Translations = {
   en: {
     giftCardPlaceholder: 'Enter and apply gift card number',
+    errorNotFound: 'The gift card number you entered is invalid. Please try again.',
+    errorExpired: 'The gift card you entered has expired.',
+    errorCurrencyNotMatch: 'The currency of the gift card does not match the currency of the cart.',
+    errorGenericError: 'We cannot process your gift card at the moment. Please try again.',
+    errorZeroBalance: 'The gift card you entered has no balance.',
   },
   de: {
     giftCardPlaceholder: 'Geschenkkartennummer eingeben und anwenden',

--- a/enabler/src/providers/definitions.ts
+++ b/enabler/src/providers/definitions.ts
@@ -16,6 +16,7 @@ export interface GiftCardBuilder {
 export type GiftCardOptions = {
   onGiftCardReady?: () => Promise<void>;
   onValueChange?: (hasValue: boolean) => Promise<void>;
+  onEnter?: () => Promise<void>;
 };
 
 export type BaseOptions = {

--- a/processor/src/clients/mock-giftcard.client.ts
+++ b/processor/src/clients/mock-giftcard.client.ts
@@ -56,6 +56,13 @@ export class GiftCardClient {
           });
         }
 
+        if (amount === '0') {
+          return this.promisify({
+            message: 'The gift card provided has no balance.',
+            code: GiftCardCodeType.ZERO_BALANCE,
+          });
+        }
+
         if (this.currency !== currency) {
           return this.promisify({
             message: 'cart and gift card currency do not match',
@@ -124,7 +131,6 @@ export class GiftCardClient {
     return this.promisify({
       result: 'SUCCESS',
       id: `mock-connector-rollback-id-${randomUUID()}`,
-      amount: 1000,
     });
   }
 

--- a/processor/src/clients/types/mock-giftcard.client.type.ts
+++ b/processor/src/clients/types/mock-giftcard.client.type.ts
@@ -42,6 +42,7 @@ export enum GiftCardCodeType {
   CURRENCY_NOT_MATCH = 'CurrencyNotMatch',
   NOT_FOUND = 'NotFound',
   INVALID = 'Invalid',
+  ZERO_BALANCE = 'ZeroBalance',
 }
 
 /* Mock mechanism to differentiate scenarios of redemption rollback.

--- a/processor/src/services/abstract-giftcard.service.ts
+++ b/processor/src/services/abstract-giftcard.service.ts
@@ -112,7 +112,7 @@ export abstract class AbstractGiftCardService {
       id: ctPayment.id,
       transaction: {
         type: transactionType,
-        amount: res.amountRefunded ? res.amountRefunded : requestAmount,
+        amount: requestAmount,
         interactionId: res.pspReference,
         state: this.convertPaymentModificationOutcomeToState(res.outcome),
       },

--- a/processor/src/services/converters/balance-converter.ts
+++ b/processor/src/services/converters/balance-converter.ts
@@ -34,6 +34,12 @@ export class BalanceConverter {
           code: 404,
           key: GiftCardCodeType.NOT_FOUND,
         });
+      case GiftCardCodeType.ZERO_BALANCE:
+        throw new MockCustomError({
+          message: opts.message || 'Gift card has no balance',
+          code: 400,
+          key: GiftCardCodeType.ZERO_BALANCE,
+        });
       default:
         throw new MockCustomError({
           message: opts.message || 'An error happened during this requests',

--- a/processor/src/services/types/operation.type.ts
+++ b/processor/src/services/types/operation.type.ts
@@ -23,7 +23,6 @@ export type RefundPaymentRequest = {
 export type PaymentProviderModificationResponse = {
   outcome: PaymentModificationStatus;
   pspReference: string;
-  amountRefunded?: AmountSchemaDTO;
 };
 
 export type StatusResponse = StatusResponseSchemaDTO;


### PR DESCRIPTION
- Changes to have valid gift cards (starting with `VOUCHER-00...`) that provides a balance but later fail to redeem
- Changes to render validation errors
- Changes to handle onEnter and allow to pass a callback when user clicks on enter
- Changes to throw new ZERO-BALANCE error