### PR TITLE
fix(giftcard): Added aria labels for a11y for error messages

### DIFF
--- a/enabler/src/components/form.ts
+++ b/enabler/src/components/form.ts
@@ -143,9 +143,22 @@ export class FormComponent extends DefaultComponent {
               <label class="${inputFieldStyles.inputLabel}" for="giftcard-code">
                 ${this.i18n.translate('giftCardPlaceholder', this.baseOptions.locale)} <span aria-hidden="true"> *</span>
               </label>
-              <input class="${inputFieldStyles.inputField}" type="text" id="giftcard-code" name="giftCardCode" value="">
-                <span class="${inputFieldStyles.hidden} ${inputFieldStyles.errorField}"></span>
-            </div>
+              <input 
+                class="${inputFieldStyles.inputField}" 
+                type="text" 
+                id="giftcard-code" 
+                name="giftCardCode" 
+                value=""
+                aria-describedby="giftcard-code-error"
+                aria-invalid="false"
+              >
+              <div 
+                id="giftcard-code-error" 
+                class="${inputFieldStyles.errorField}" 
+                role="alert"
+                aria-live="polite"
+                aria-hidden="true"
+              ></div>
           </div>
         </div>
       `;


### PR DESCRIPTION
Related [ticket](https://commercetools.atlassian.net/browse/SCC-3297)

Small fix as part of an accessibility epic. Added aria label to enable e-readers to pick up error messages for Gift Card.
<img width="1509" alt="Screenshot 2025-06-16 at 11 22 08" src="https://github.com/user-attachments/assets/94be51bf-186e-420f-9c65-2bc5d9c89d27" />
